### PR TITLE
Add --cd to change working dir, do not use 'sh'

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ stampdalf <directory> [command...]
 
 ```bash
 # Format all Go files without changing timestamps
-stampdalf ./src gofmt -w .
+stampdalf --cd ./src gofmt -w .
 
 # Build a project with reproducible timestamps
-stampdalf ./project make build
+stampdalf --cd ./project make build
 
 # Process images without affecting modification times
-stampdalf ./images mogrify -resize 50% *.jpg
+stampdalf ./images mogrify -resize 50% images/*.jpg
 
 # Set new files to specific timestamp (for reproducible builds)
-SOURCE_DATE_EPOCH=1609459200 stampdalf ./dist npm run build
+SOURCE_DATE_EPOCH=1609459200 stampdalf --cd ./dist npm run build
 ```
 
 ## How it works

--- a/main.go
+++ b/main.go
@@ -39,8 +39,8 @@ func registerDir(dir string) (map[string]FileTimestamps, error) {
 	return timestamps, err
 }
 
-func executeCommand(command string, workDir string) error {
-	cmd := exec.Command("sh", "-c", command)
+func executeCommand(command []string, workDir string) error {
+	cmd := exec.Command(command[0], command[1:]...)
 	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -83,11 +83,11 @@ func resetTimestamps(dir string, defaultStamp time.Time, timestamps map[string]F
 
 func main() {
 	if len(os.Args) < 2 {
-		log.Fatalf("Usage: %s <directory> <command>\n", os.Args[0])
+		log.Fatalf("Usage: %s <directory> <command> [args ...]\n", os.Args[0])
 	}
 
 	dir := os.Args[1]
-	command := shellquote.Join(os.Args[2:]...)
+	command := os.Args[2:]
 
 	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
 		log.Fatalf("Error: %s is not a valid directory\n", dir)
@@ -102,7 +102,7 @@ func main() {
 	log.Printf("Found %d files/directories\n", len(originalTimestamps))
 
 	// Step 2: Execute command
-	log.Printf("Executing command: %s\n", command)
+	log.Printf("Executing command: %s\n", shellquote.Join(command...))
 	if err := executeCommand(command, dir); err != nil {
 		log.Fatalf("Command failed: %v\n", err)
 	}


### PR DESCRIPTION
2 things

  * Only change working directory to directory when asked.
    If the user wants to change to <dir> before executing <cmd>,
    they now need to 'stampaldf --cd <dir> <cmd>', or just
    ( cd dir && stampaldf . <cmd> ).
    
    The reason to not do this by default is that if 'cmd' has
    any references to filesystem paths that are relative to
    the callers working directory, then they'll be broken.
    
    Ie, previously this would fail:
    
        mkdir foo
        touch bar
        touch foo/subfile
        stampaldf foo rm bar
    
    Which is weird.  You don't expect commands to change their
    working directory.
    
    If I wanted that, I could just do this:
    
        sh -c 'cd foo && stampaldf . rm subfile'
    
    Or, alternatively if you want it you can now do:
    
        stampaldf --cd . rm subfile

  * Do not use sh -c, but rather execute the command provided.
    
    If the user wants to hand something off to sh -c, then they
    can just provide 'sh' and '-c' as arguments.

    Fixes: #1 